### PR TITLE
:princess: Add vendor directory itself to defaultExcludes

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
 	defaultExcludes = []string{
 		"**/*.swp",
 		"**/*.swx",
+		"vendor",
 		"vendor/**",
 		".git",
 		".ignore",


### PR DESCRIPTION
Actually, the vendor directory is not filtered out.
Should not be a problem because it should only contain directory but 👸 
And it could be confusing to see it in the list of watched directory:
```
 INFO Watching directories: ., [...] vendor
```